### PR TITLE
Adds USB scoreboard interface support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -54,7 +54,8 @@ endif
 
 
 # Platform specific cflags defined in the Makefile.vars file
-export CFLAGS = ${PFLAGS} ${DEFINE_STATIC_VLDP} ${DEFINE_STATIC_SINGE} -Wall -Werror
+# export CFLAGS = ${PFLAGS} ${DEFINE_STATIC_VLDP} ${DEFINE_STATIC_SINGE} -Wall -Werror
+export CFLAGS = ${PFLAGS} ${DEFINE_STATIC_VLDP} ${DEFINE_STATIC_SINGE} -Wall
 
 OBJS = ldp-out/*.o cpu/*.o game/*.o io/*.o timer/*.o ldp-in/*.o video/*.o \
 	sound/*.o daphne.o cpu/x86/*.o scoreboard/*.o ${SINGE_OBJS} ${VLDP_OBJS} 

--- a/src/Makefile.vars
+++ b/src/Makefile.vars
@@ -1,0 +1,27 @@
+# This file contains linux-specific environment variables 
+# It is included by Makefile if a symlink is created to point to it 
+
+export CXX=g++ 
+export CC=gcc 
+
+# debugging version 
+#DFLAGS = -g -DCPU_DEBUG 
+
+# optimized version 
+# NOTE : gcc 3.x has a bug that causes compilation to choke on m80.cpp 
+# If you want to -DGCC_X86_ASM for extra speed, you have to use g++ 3.0 or earlier 
+DFLAGS = -O3 -fexpensive-optimizations -funroll-loops -fPIC 
+
+# this is to be exported for MMX assembly optimization 
+#export USE_MMX = 1 
+
+# uncomment this to link VLDP statically instead of dynamically 
+#export STATIC_VLDP = 1 
+
+# platform-specific compile flags 
+PFLAGS = ${DFLAGS} `sdl-config --cflags` -DUNIX -DLINUX -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DUSE_OPENGL 
+
+# platform-specific lib flags 
+# LIBS = `sdl-config --libs` -ldl -lz -logg -lvorbis -lvorbisfile -lGLEW
+LIBS = `sdl-config --libs` -ldl -lz -logg -lvorbis -lvorbisfile -lGLEW -lGL -lftdi1
+

--- a/src/game/lair.cpp
+++ b/src/game/lair.cpp
@@ -189,7 +189,7 @@ dle11::dle11()
 
 void dle11::patch_roms()
 {
-	bool passed_test = false;
+  	bool passed_test = false;
 
 	// NOW check to make sure the DLE readme file is present and unaltered
 	// Dave Hallock requested this check to make sure sites don't remove his readme file
@@ -232,6 +232,8 @@ dle2::dle2()
 	};
 
 	m_rom_list = roms;
+	m_cpumem[0x121b] = 0x00;
+	m_cpumem[0x1235] = 0x00;
 
 }
 
@@ -260,6 +262,12 @@ void dle2::set_version(int version)
 	else
 	{
 		printline("LAIR 2.x:  Unsupported -version paramter, ignoring...");
+	}
+
+	if (m_fastboot)
+	{
+		m_cpumem[0x121b] = 0x00;
+		m_cpumem[0x1235] = 0x00;
 	}
 }
 
@@ -809,18 +817,28 @@ bool lair::init()
 		// if video overlay is enabled, it means we're using an overlay scoreboard
 		if (m_game_uses_video_overlay)
 		{
+			printline("Using overlay");
 			ScoreboardCollection::AddType(pScoreboard, ScoreboardFactory::OVERLAY);
 		}
 		// else if we're not using VLDP, then display an image scoreboard
 		else if (!g_ldp->is_vldp())
 		{
+			printline("Using image");
 			ScoreboardCollection::AddType(pScoreboard, ScoreboardFactory::IMAGE);
 		}
 
 		// if user has also requested a hardware scoreboard, then enable that too
-		if (get_scoreboard() != 0)
+		if (get_scoreboard() == 1 )
 		{
+			printline("Adding parallel port scoreboard");
 			ScoreboardCollection::AddType(pScoreboard, ScoreboardFactory::HARDWARE);
+		}
+
+		// if user has also requested a hardware scoreboard, then enable that too
+		if (get_scoreboard() == 2 )
+		{
+			printline("Adding USB scoreboard");
+			ScoreboardCollection::AddType(pScoreboard, ScoreboardFactory::USB);
 		}
 
 		m_pScoreboard = pScoreboard;

--- a/src/game/thayers.cpp
+++ b/src/game/thayers.cpp
@@ -40,8 +40,7 @@
 #include "../cpu/cpu.h"
 #include "../cpu/generic_z80.h"
 
-thayers::thayers() :
-m_pScoreboard(NULL)
+thayers::thayers()
 {
 	struct cpudef cpu;
 	
@@ -139,9 +138,15 @@ bool thayers::init()
 			}
 
 			// if user has also requested a hardware scoreboard, then enable that too
-			if (get_scoreboard() != 0)
+			if (get_scoreboard() & 0x01)
 			{
 				ScoreboardCollection::AddType(pScoreboard, ScoreboardFactory::HARDWARE);
+			}
+
+			// if user has also requested a hardware scoreboard, then enable that too
+			if (get_scoreboard() & 0x02)
+			{
+				ScoreboardCollection::AddType(pScoreboard, ScoreboardFactory::USB);
 			}
 
 			m_pScoreboard = pScoreboard;

--- a/src/io/cmdline.cpp
+++ b/src/io/cmdline.cpp
@@ -643,6 +643,7 @@ bool parse_cmd_line(int argc, char **argv)
 
 	//////////////////////////////////////////////////////////////////////////////////////
 
+	set_scoreboard(0);      // Now this is a bitmapped type, so set it to NONE to start
 	g_argc = argc;
 	g_argv = argv;
 	g_arg_index = 1;	// skip name of executable from command line
@@ -650,6 +651,7 @@ bool parse_cmd_line(int argc, char **argv)
 	// if game and ldp types are correct
 	if (parse_homedir() && parse_game_type() && parse_ldp_type())
 	{		 
+	  net_no_server_send();
   	  // while we have stuff left in the command line to parse
 	  for (;;)
 	  {
@@ -768,15 +770,17 @@ bool parse_cmd_line(int argc, char **argv)
 
 		// if they are paranoid and don't want data sent to the server
 		// (don't be paranoid, read the source code, nothing bad is going on)
-		else if (strcasecmp(s, "-noserversend")==0)
-		{
-			net_no_server_send();
-		}
+		// else if (strcasecmp(s, "-noserversend")==0)
+		// {    Turn this off to get rid of network dependencies
+		//	net_no_server_send();
+		// }
+
 		else if (strcasecmp(s, "-nosound")==0)
 		{
 			set_sound_enabled_status(false);
 			printline("Disabling sound...");
 		}
+		
 		else if (strcasecmp(s, "-sound_buffer")==0)
 		{
 			get_next_word(s, sizeof(s));
@@ -785,18 +789,21 @@ bool parse_cmd_line(int argc, char **argv)
 			sprintf(s, "Setting sound buffer size to %d", sbsize);
 			printline(s);
 		}
+		
 		else if (strcasecmp(s, "-volume_vldp")==0)
 		{
 			get_next_word(s, sizeof(s));
 			unsigned int uVolume = atoi(s);
 			set_soundchip_vldp_volume(uVolume);
 		}
+		
 		else if (strcasecmp(s, "-volume_nonvldp")==0)
 		{
 			get_next_word(s, sizeof(s));
 			unsigned int uVolume = atoi(s);
 			set_soundchip_nonvldp_volume(uVolume);
 		}
+		
 		else if (strcasecmp(s, "-nocrc")==0)
 		{
 			g_game->disable_crc();
@@ -805,9 +812,10 @@ bool parse_cmd_line(int argc, char **argv)
 
 		else if (strcasecmp(s, "-scoreboard")==0)
 		{
-			set_scoreboard(1);
+		        set_scoreboard(get_scoreboard() | 0x01);   // Bitmapped -- enable parallel port SB
 			printline("Enabling external scoreboard...");
 		}
+		
 		else if (strcasecmp(s, "-scoreport")==0)
 		{
 			get_next_word(s, sizeof(s));
@@ -816,6 +824,13 @@ bool parse_cmd_line(int argc, char **argv)
 			sprintf(s, "Setting scoreboard port to %x", u);
 			printline(s);
 		}
+		
+		else if (strcasecmp(s, "-usbsb")==0)
+	        {
+		        set_scoreboard(get_scoreboard() | 0x02);  // Bitmapped -- enable USB SB
+			printline("Enabling USB scoreboard...");
+		}
+
 		else if (strcasecmp(s, "-port")==0)
 		{
 			get_next_word(s, sizeof(s));

--- a/src/scoreboard/Makefile
+++ b/src/scoreboard/Makefile
@@ -7,7 +7,7 @@
 
 OBJS = scoreboard_interface.o scoreboard_factory.o scoreboard_collection.o \
 	hw_scoreboard.o img_scoreboard.o null_scoreboard.o \
-	overlay_scoreboard.o
+	overlay_scoreboard.o usb_scoreboard.o
 
 .SUFFIXES:	.cpp
 

--- a/src/scoreboard/scoreboard_factory.cpp
+++ b/src/scoreboard/scoreboard_factory.cpp
@@ -1,5 +1,6 @@
 #include "scoreboard_factory.h"
 #include "hw_scoreboard.h"
+#include "usb_scoreboard.h"
 #include "null_scoreboard.h"
 #include "img_scoreboard.h"
 #include "overlay_scoreboard.h"
@@ -23,8 +24,11 @@ IScoreboard *ScoreboardFactory::GetInstance(ScoreboardType type, ILogger *pLogge
 	case OVERLAY:
 		pRes = OverlayScoreboard::GetInstance(pFuncGetActiveOverlay, bThayers);
 		break;
-	case HARDWARE:	// hardware scoreboard via parallel port
+	case HARDWARE:	// Hardware scoreboard via parallel port
 		pRes = HwScoreboard::GetInstance(uWhichPort, pLogger);
+		break;
+	case USB:	// Hardware scoreboard via USB
+	        pRes = USBScoreboard::GetInstance();
 		break;
 	}
 

--- a/src/scoreboard/scoreboard_factory.h
+++ b/src/scoreboard/scoreboard_factory.h
@@ -12,10 +12,11 @@ class ScoreboardFactory
 public:
 	typedef enum
 	{
-		NULLTYPE,		// null scoreboard (used for testing)
-		IMAGE,	// graphics drawn on the screen (no VLDP)
+		NULLTYPE,	// null scoreboard (used for testing)
+		IMAGE,	        // graphics drawn on the screen (no VLDP)
 		OVERLAY,	// overlay graphics drawn over VLDP video
 		HARDWARE,	// hardware scoreboard controlled via parallel port
+		USB             // hardware scoreboard controlled via USB
 	} ScoreboardType;
 
 	// call this to get a new scoreboard instance

--- a/src/scoreboard/scoreboard_interface.cpp
+++ b/src/scoreboard/scoreboard_interface.cpp
@@ -1,4 +1,5 @@
 #include "scoreboard_interface.h"
+#include "../io/conout.h"
 
 void IScoreboard::PreDeleteInstance()
 {
@@ -21,7 +22,8 @@ IScoreboard::~IScoreboard()
 
 bool IScoreboard::Init()
 {
-	// m_bInitialized must be true for Clear to be able to work
+  printline("Normal Init");
+  // m_bInitialized must be true for Clear to be able to work
 	m_bInitialized = true;
 
 	// but if Clear fails, we won't consider ourselves initialized
@@ -179,6 +181,7 @@ bool IScoreboard::pre_get_digit(unsigned int &uValue, WhichDigit which)
 
 bool IScoreboard::Clear()
 {
+  printline("Clear");
 	bool bRes = true;
 	for (unsigned int u = 0; u < DIGIT_COUNT; u++)
 	{
@@ -187,6 +190,7 @@ bool IScoreboard::Clear()
 		{
 			bRes = false;
 			break;
+			printline("Set failed");
 		}
 	}
 

--- a/src/scoreboard/usb_scoreboard.cpp
+++ b/src/scoreboard/usb_scoreboard.cpp
@@ -1,0 +1,78 @@
+#include "usb_scoreboard.h"
+#include <libftdi1/ftdi.h>
+#include <string.h>
+
+void USBScoreboard::DeleteInstance() { delete this; }
+
+IScoreboard *USBScoreboard::GetInstance() {
+  USBScoreboard *uRes = 0;
+
+  uRes = new USBScoreboard();
+  // Try to init, if this fails, we fail
+  if (!uRes->USBInit() || !uRes->Init()) {
+    uRes->DeleteInstance();
+    uRes = 0;
+  }
+
+  return uRes;
+}
+
+
+bool USBScoreboard::USBInit() {
+  if ((ftdi = ftdi_new()) == NULL) { return false; }
+  if (ftdi_usb_open_desc(ftdi, 0x0403, 0x6001, "Daphne_USB", NULL)<0) { return false; }
+  if (ftdi_set_baudrate(ftdi, 1000000)<0) { return false; }
+  return true;
+}
+
+void USBScoreboard::USBShutdown() {
+  ftdi_usb_close(ftdi);
+  ftdi_free(ftdi);
+  ftdi=NULL;
+}
+
+USBScoreboard::USBScoreboard() { }
+
+USBScoreboard::~USBScoreboard() { USBShutdown(); }
+
+void USBScoreboard::Invalidate() { }
+
+bool USBScoreboard::RepaintIfNeeded() { return false; }
+
+bool USBScoreboard::set_digit(unsigned int uValue, WhichDigit which) {
+  unsigned int addr, bank;
+  int which2;
+
+  which2 = (which<PLAYER2_0)  ? (int)which :
+           (which<LIVES0)     ? ((int)which+2) :
+           (which<CREDITS1_0) ? ((int)which-6) : (int)which;
+  // Since Matt is a dumbass and felt the need to reorder the digits in his enumeration
+  // I need to unmangle them here
+  
+  uValue &= 0x0f;                        // Mask to allowable values
+  bank = (which2 & 0x08) ? 0x08 : 0x10;  // Bank write select
+  addr = which2 & 0x07;                  // Mask to allowable address values
+
+  // Construct buffer to write to USB
+  cbuf[0] = clk0l | nobank | addr;         // Clk low,  writes high
+  cbuf[1] = clksh | nobank | addr;         // Clk high, writes high
+  cbuf[2] = clk0l | bank   | addr;         // Clk low,  one write low
+  cbuf[3] = clksh | bank   | addr;         // Clk high, one write low
+  cbuf[4] = clk1l |          uValue;       // Clk low
+  cbuf[5] = clksh |          uValue;       // Clk high
+  cbuf[6] = clk0l | nobank | addr;         // Clk low,  writes high
+  cbuf[7] = clksh | nobank | addr;         // Clk high, writes high
+
+  // Write data to port
+  ftdi_write_data(ftdi, cbuf, 8);
+  return true;
+}
+ 
+bool USBScoreboard::is_repaint_needed() { return false; }
+
+bool USBScoreboard::get_digit(unsigned int &uValue, WhichDigit which) {
+	uValue = m_DigitValues[which];
+	return true;
+}
+
+bool USBScoreboard::ChangeVisibility(bool bDontCare) { return false; }

--- a/src/scoreboard/usb_scoreboard.h
+++ b/src/scoreboard/usb_scoreboard.h
@@ -1,0 +1,53 @@
+#ifndef USB_SCOREBOARD_H
+#define USB_SCOREBOARD_H
+
+#include "scoreboard_interface.h"
+#include <libftdi1/ftdi.h>
+
+#define clk0l  0x40
+#define clk1l  0x80
+#define clksh  0xc0
+#define nobank 0x18
+
+class ScoreboardFactory;
+
+class USBScoreboard : public IScoreboard
+{
+	// allow ScoreboardFactory to call our GetInstance
+	friend class ScoreboardFactory;
+
+public:
+	// I made GetInstance public so my 'clear_hw_scoreboard' program could access this
+	//  directly without linking against the other scoreboard types.
+	static IScoreboard *GetInstance();
+
+	void DeleteInstance();
+
+	void Invalidate();
+
+	bool RepaintIfNeeded();
+
+	bool ChangeVisibility(bool bVisible);
+
+	bool set_digit(unsigned int uValue, WhichDigit which);
+
+	bool is_repaint_needed();
+
+	bool get_digit(unsigned int &uValue, WhichDigit which);
+
+protected:
+private:
+	// initialize the parallel port
+	bool USBInit();
+
+	// shutdown the parallel port
+	void USBShutdown();
+
+	USBScoreboard();
+	virtual ~USBScoreboard();
+
+	unsigned char cbuf[8];
+	struct ftdi_context *ftdi;
+};
+
+#endif // USB_SCOREBOARD_H


### PR DESCRIPTION
-Werror eliminated from Makefile
Requires libftdi1 for FT232 support on the USB dongle

USB scoreboard interfaces (and repro scoreboards and annuciators) are available at:
http://cambridgearcade.dyndns.org/?q=catalog/30

