### PR TITLE
Fix ambiguous cast syntax

### DIFF
--- a/src/cpu/nes6502.cpp
+++ b/src/cpu/nes6502.cpp
@@ -297,10 +297,10 @@
    if (condition) \
    { \
       IMMEDIATE_BYTE(btemp); \
-      if (((int8) btemp + (PC & 0x00FF)) & 0x100) \
+      if (((int8_t) btemp + (PC & 0x00FF)) & 0x100) \
          ADD_CYCLES(1); \
       ADD_CYCLES(3); \
-      PC += ((int8) btemp); \
+      PC += ((int8_t) btemp); \
    } \
    else \
    { \


### PR DESCRIPTION
This crashed Road Blaster on the Pi.
In systems that worked, this casted the value to an actual signed int8 (-128 to 127).
On the Pi, it didn't.
Road Blaster works now.