### PR TITLE
Add -fsigned-char to key Makefiles

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -54,7 +54,7 @@ endif
 
 
 # Platform specific cflags defined in the Makefile.vars file
-CFLAGS += ${PFLAGS} ${DEFINE_STATIC_VLDP} ${DEFINE_STATIC_SINGE} -Wall
+CFLAGS += ${PFLAGS} ${DEFINE_STATIC_VLDP} ${DEFINE_STATIC_SINGE} -Wall -fsigned-char
 
 OBJS = ldp-out/*.o cpu/*.o game/*.o io/*.o timer/*.o ldp-in/*.o video/*.o \
 	sound/*.o daphne.o cpu/x86/*.o scoreboard/*.o ${SINGE_OBJS} ${VLDP_OBJS} 

--- a/src/vldp2/Makefile.rp
+++ b/src/vldp2/Makefile.rp
@@ -1,7 +1,7 @@
 # Makefile for VLDP2
 # Written by Matt Ownby
 
-CFLAGS += ${DFLAGS} -fPIC `sdl-config --cflags` -I./include
+CFLAGS += ${DFLAGS} -fPIC `sdl-config --cflags` -I./include -fsigned-char 
 LIBS = `sdl-config --libs`
 
 OBJS =  vldp/vldp.o vldp/vldp_internal.o vldp/mpegscan.o \


### PR DESCRIPTION
Forces VLDP and Daphne to be compiled with explicit strict signed char handling, which is required for specific CPU calculations.